### PR TITLE
Fixes copy crashpad_handler build step on Ubuntu

### DIFF
--- a/Crashpad/Tools/Linux/symbols.sh
+++ b/Crashpad/Tools/Linux/symbols.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 dump_syms="${1}/Crashpad/Tools/Linux/dump_syms"
 symupload="${1}/Crashpad/Tools/Linux/symupload"
 app="${2}/${4}.debug"

--- a/myQtCrasher.pro
+++ b/myQtCrasher.pro
@@ -94,7 +94,7 @@ linux {
     LIBS += -L$$PWD/Crashpad/Libraries/Linux/ -lbase
 
     # Copy crashpad_handler to build directory and run dump_syms and symupload
-    QMAKE_POST_LINK += "cp $$PWD/Crashpad/Bin/Linux/crashpad_handler $$OUT_PWD/crashpad"
-    QMAKE_POST_LINK += "&& bash $$PWD/Crashpad/Tools/Linux/symbols.sh $$PWD $$OUT_PWD fred myQtCrasher 1.0 > $$PWD/Crashpad/Tools/Linux/symbols.out 2>&1"
+    QMAKE_POST_LINK += "mkdir -p $$OUT_PWD/crashpad && cp $$PWD/Crashpad/Bin/Linux/crashpad_handler $$OUT_PWD/crashpad/crashpad_handler"
+    QMAKE_POST_LINK += "&& $$PWD/Crashpad/Tools/Linux/symbols.sh $$PWD $$OUT_PWD fred myQtCrasher 1.0 > $$PWD/Crashpad/Tools/Linux/symbols.out 2>&1"
     QMAKE_POST_LINK += "&& cp $$PWD/Crashpad/attachment.txt $$OUT_PWD/attachment.txt"
 }


### PR DESCRIPTION
Also makes Crashpad/Tools/Linux/symbols.sh executable.

Fixes #14 