### PR TITLE
Fix linux build issue under GCC/ARM/Qt5.15

### DIFF
--- a/Crashpad/Tools/Linux/symbols.sh
+++ b/Crashpad/Tools/Linux/symbols.sh
@@ -6,4 +6,5 @@ sym="${4}.sym"
 url="https://${3}.bugsplat.com/post/bp/symbol/breakpadsymbols.php?appName=${4}&appVer=${5}"
 
 eval "${dump_syms} ${app} > ${sym}"
+sed -i "1s/.debug//" $sym
 eval $"${symupload} \"${sym}\" \"${url}\""


### PR DESCRIPTION
Qt build process causes the module name to get munged by the build process, have script fix-up the module name.

### Description

The Qt build process causes the module name to get munged by the build process.
Qt is having objcopy strip the exe of symbols and put the symbols into another executable, with a ".debug" extension. When dump_syms reads this debug symbol executable, it generates a symbol module name that is the "appname.debug".  This causes minidump_stackwalk to not resolve the symbols and not properly walk the stack. This also applies to your website, it also does not walk the stack properly given the bad symbol file. 

I have tested this with the following configuration:
Linux raspberrypi 5.10.103-v7+ #1530 SMP Tue Mar 8 13:02:44 GMT 2022 armv7l GNU/Linux
gcc (Raspbian 10.2.1-6+rpi1) 10.2.1 20210110
GNU objcopy (GNU Binutils for Raspbian) 2.35.2 
QMake version 3.1, Using Qt version 5.15.2 in /usr/lib/arm-linux-gnueabihf

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
