### PR TITLE
fix: download symbol-upload just-in-time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,9 @@ Thumbs.db
 
 # Qt
 build
+
+# Symbol Uploaders
+Crashpad/Tools/MacOS/symbol-upload-macos
+Crashpad/Tools/MacOS/symbol-upload-macos-intel
+Crashpad/Tools/Linux/symbol-upload-linux
+Crashpad/Tools/Windows/symbol-upload-windows.exe

--- a/Crashpad/Tools/Linux/symbol-upload-linux
+++ b/Crashpad/Tools/Linux/symbol-upload-linux
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1eaf70d2cc82aa89a3dd7301d91322e43d44c0f6ac1e8fa30e5b011dd7a712ab
-size 133500032

--- a/Crashpad/Tools/Linux/symbols.sh
+++ b/Crashpad/Tools/Linux/symbols.sh
@@ -8,4 +8,9 @@ file="${4}.debug"
 user="${6}"
 password="${7}"
 
+if [ ! -f "${symbol_upload}" ]; then
+    echo "Downloading symbol-upload-linux"
+    curl -sL -O "https://app.bugsplat.com/download/symbol-upload-linux" && chmod +x symbol-upload-linux
+fi
+
 eval "${symbol_upload} -b ${database} -a \"${app}\" -v \"${version}\" -d \"${dir}\" -f \"${file}\" -u \"${user}\" -p \"${password}\" -m"

--- a/Crashpad/Tools/MacOS/symbol-upload-macos
+++ b/Crashpad/Tools/MacOS/symbol-upload-macos
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c683eca44dc9c7b402fb2a6cef9a3a8c0f1379a747874c8d6695a458a21f4db
-size 118064080
+oid sha256:d98e351c6db5e6b59747aacd5ca4c838e2acb3f5982dc1471f213e6e7fa6cfb4
+size 125391024

--- a/Crashpad/Tools/MacOS/symbols.sh
+++ b/Crashpad/Tools/MacOS/symbols.sh
@@ -1,4 +1,3 @@
-symbol_upload="${1}/Crashpad/Tools/MacOS/symbol-upload-macos"
 database="${3}"
 app="${4}"
 version="${5}"
@@ -6,6 +5,27 @@ dir="${2}"
 file="${4}.app.dSYM"
 user="${6}"
 password="${7}"
+arch="${8}"
 
+if [ "${arch}" = "arm64" ]; then
+    echo "Uploading symbols for arm64"
+    symbol_upload_flavor="symbol-upload-macos"
+elif [ "${arch}" = "x86_64" ]; then
+    echo "Uploading symbols for intel"
+    symbol_upload_flavor="symbol-upload-macos-intel"
+else
+    echo "Error: Unknown architecture '${arch}'. Must be 'arm64' or 'x86_64'"
+    exit 1
+fi
+
+echo "Using ${symbol_upload_flavor}"
+symbol_upload="${1}/Crashpad/Tools/MacOS/${symbol_upload_flavor}"
+
+if [ ! -f "${symbol_upload}" ]; then
+    echo "Downloading ${symbol_upload_flavor}"
+    curl -sL -O "https://app.bugsplat.com/download/${symbol_upload_flavor}" && chmod +x ${symbol_upload_flavor}
+fi
+
+echo "Uploading symbols to ${database}"
 eval "${symbol_upload} -b ${database} -a \"${app}\" -v \"${version}\" -d \"${dir}\" -f \"${file}\" -u \"${user}\" -p \"${password}\" -m"
 

--- a/Crashpad/Tools/Windows/symbols.bat
+++ b/Crashpad/Tools/Windows/symbols.bat
@@ -1,1 +1,0 @@
-%1\Crashpad\Tools\Windows\symbol-upload-windows.exe -b %3 -a "%4" -v "%5" -d "%2" -f "%4.exe" -u "%6" -p "%7" -m

--- a/Crashpad/Tools/Windows/symbols.ps1
+++ b/Crashpad/Tools/Windows/symbols.ps1
@@ -1,0 +1,39 @@
+param(
+    [Parameter(Mandatory=$true)][string]$rootPath,      # %1
+    [Parameter(Mandatory=$true)][string]$symbolsDir,    # %2
+    [Parameter(Mandatory=$true)][string]$database,      # %3
+    [Parameter(Mandatory=$true)][string]$appName,       # %4
+    [Parameter(Mandatory=$true)][string]$version,       # %5
+    [Parameter(Mandatory=$true)][string]$username,      # %6
+    [Parameter(Mandatory=$true)][string]$password       # %7
+)
+
+$symbolUploader = Join-Path $rootPath "Crashpad\Tools\Windows\symbol-upload-windows.exe"
+$symbolFile = "$appName.exe"
+
+if (-not (Test-Path $symbolUploader)) {
+    Write-Host "Downloading symbol-upload-windows.exe..."
+    $downloaderDir = Split-Path -Parent $symbolUploader
+    if (-not (Test-Path $downloaderDir)) {
+        New-Item -ItemType Directory -Path $downloaderDir -Force | Out-Null
+    }
+    try {
+        Invoke-WebRequest -Uri "https://app.bugsplat.com/download/symbol-upload-windows.exe" -OutFile $symbolUploader
+        if (-not (Test-Path $symbolUploader)) {
+            Write-Error "Failed to download symbol-upload-windows.exe"
+            exit 1
+        }
+        Write-Host "Successfully downloaded symbol-upload-windows.exe"
+    }
+    catch {
+        Write-Error "Failed to download symbol-upload-windows.exe: $_"
+        exit 1
+    }
+}
+
+& $symbolUploader -b $database -a $appName -v $version -d $symbolsDir -f $symbolFile -u $username -p $password -m
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Symbol upload failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+} 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ BugSplat has created a [Crashpad fork](https://github.com/BugSplat-Git/crashpad)
 
 ### Additional Considerations
 
-If you change the BugSplat `database`, `application`, or `version` values in `main.cpp`, be sure to update the corresponding variables in the [myQtCrasher.pro file](https://github.com/BugSplat-Git/my-qt-crasher/blob/fc55bad38929f21a431c965abcfd3a17b1b91e45/myQtCrasher.pro#L38-L43). The `symbols.sh` scripts are responsible for running `symbol-upload` on macOS and Linux. Likewise, `symbols.bat` is responsible for running `symbol-upload` on Windows. If the values passed to `symbols.sh` or `symbols.bat` via the `QMAKE_POST_LINK` command are wrong then you will not see file names or line numbers in your crash reports.
+If you change the BugSplat `database`, `application`, or `version` values in `main.cpp`, be sure to update the corresponding variables in the [myQtCrasher.pro file](https://github.com/BugSplat-Git/my-qt-crasher/blob/fc55bad38929f21a431c965abcfd3a17b1b91e45/myQtCrasher.pro#L38-L43). The `symbols.sh` scripts are responsible for running `symbol-upload` on macOS and Linux. Likewise, `symbols.ps1` is responsible for running `symbol-upload` on Windows. If the values passed to `symbols.sh` or `symbols.ps1` via the `QMAKE_POST_LINK` command are wrong then you will not see file names or line numbers in your crash reports.
 
 ## 👷 Support
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,17 +1,17 @@
 #include "mainwindow.h"
 
 #if defined(Q_OS_WIN)
-    #define NOMINMAX
-    #include <windows.h>
+#define NOMINMAX
+#include <windows.h>
 #endif
 
 #if defined(Q_OS_MAC)
-    #include <mach-o/dyld.h>
+#include <mach-o/dyld.h>
 #endif
 
 #if defined(Q_OS_LINUX)
-    #include <unistd.h>
-    #define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#include <unistd.h>
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #endif
 
 #include <QApplication>
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
 {
     QString dbName = "Fred";
     QString appName = "myQtCrasher";
-    QString appVersion = "1.1";
+    QString appVersion = "1.2";
 
     initializeCrashpad(dbName, appName, appVersion);
 
@@ -69,7 +69,8 @@ bool initializeCrashpad(QString dbName, QString appName, QString appVersion)
     annotations["version"] = appVersion.toStdString();  // Required: BugSplat appVersion
     annotations["key"] = "Sample key";                  // Optional: BugSplat key field
     annotations["user"] = "fred@bugsplat.com";          // Optional: BugSplat user email
-    annotations["list_annotations"] = "Sample comment";	// Optional: BugSplat crash description
+    annotations["list_annotations"] = "Sample comment"; // Optional: BugSplat crash description
+    annotations["attribute"] = "test attribute";        // Optional: BugSplat attribute
 
     // Disable crashpad rate limiting so that all crashes have dmp files
     std::vector<std::string> arguments;
@@ -77,11 +78,13 @@ bool initializeCrashpad(QString dbName, QString appName, QString appVersion)
 
     // Initialize crashpad database
     std::unique_ptr<CrashReportDatabase> database = CrashReportDatabase::Initialize(reportsDir);
-    if (database == NULL) return false;
+    if (database == NULL)
+        return false;
 
     // Enable automated crash uploads
     Settings *settings = database->GetSettings();
-    if (settings == NULL) return false;
+    if (settings == NULL)
+        return false;
     settings->SetUploadsEnabled(true);
 
     // Attachments to be uploaded alongside the crash - default bundle size limit is 20MB
@@ -95,19 +98,21 @@ bool initializeCrashpad(QString dbName, QString appName, QString appVersion)
     return status;
 }
 
-QString getExecutableDir() {
+QString getExecutableDir()
+{
 #if defined(Q_OS_MAC)
     unsigned int bufferSize = 512;
     std::vector<char> buffer(bufferSize + 1);
 
-    if(_NSGetExecutablePath(&buffer[0], &bufferSize))
+    if (_NSGetExecutablePath(&buffer[0], &bufferSize))
     {
         buffer.resize(bufferSize);
         _NSGetExecutablePath(&buffer[0], &bufferSize);
     }
 
-    char* lastForwardSlash = strrchr(&buffer[0], '/');
-    if (lastForwardSlash == NULL) return NULL;
+    char *lastForwardSlash = strrchr(&buffer[0], '/');
+    if (lastForwardSlash == NULL)
+        return NULL;
     *lastForwardSlash = 0;
 
     return &buffer[0];
@@ -115,10 +120,12 @@ QString getExecutableDir() {
     HMODULE hModule = GetModuleHandleW(NULL);
     WCHAR path[MAX_PATH];
     DWORD retVal = GetModuleFileNameW(hModule, path, MAX_PATH);
-    if (retVal == 0) return NULL;
+    if (retVal == 0)
+        return NULL;
 
     wchar_t *lastBackslash = wcsrchr(path, '\\');
-    if (lastBackslash == NULL) return NULL;
+    if (lastBackslash == NULL)
+        return NULL;
     *lastBackslash = 0;
 
     return QString::fromWCharArray(path);
@@ -126,16 +133,18 @@ QString getExecutableDir() {
     char pBuf[FILENAME_MAX];
     int len = sizeof(pBuf);
     int bytes = MIN(readlink("/proc/self/exe", pBuf, len), len - 1);
-    if (bytes >= 0) {
+    if (bytes >= 0)
+    {
         pBuf[bytes] = '\0';
     }
 
-    char* lastForwardSlash = strrchr(&pBuf[0], '/');
-    if (lastForwardSlash == NULL) return NULL;
+    char *lastForwardSlash = strrchr(&pBuf[0], '/');
+    if (lastForwardSlash == NULL)
+        return NULL;
     *lastForwardSlash = '\0';
 
     return QString::fromStdString(pBuf);
 #else
-    #error getExecutableDir not implemented on this platform
+#error getExecutableDir not implemented on this platform
 #endif
 }

--- a/myQtCrasher.pro
+++ b/myQtCrasher.pro
@@ -114,6 +114,6 @@ linux {
 
     # Copy crashpad_handler, attachment.txt to build directory, and upload symbols
     QMAKE_POST_LINK += "mkdir -p $$OUT_PWD/crashpad && cp $$PWD/Crashpad/Bin/Linux/crashpad_handler $$OUT_PWD/crashpad/crashpad_handler"
-    QMAKE_POST_LINK += "&& $$PWD/Crashpad/Tools/Linux/symbols.sh $$PWD $$OUT_PWD $$BUGSPLAT_DATABASE $$BUGSPLAT_APPLICATION $$BUGSPLAT_VERSION $$BUGSPLAT_USER $$BUGSPLAT_PASSWORD"
+    QMAKE_POST_LINK += "&& cd $$PWD/Crashpad/Tools/Linux && ./symbols.sh $$PWD $$OUT_PWD $$BUGSPLAT_DATABASE $$BUGSPLAT_APPLICATION $$BUGSPLAT_VERSION $$BUGSPLAT_USER $$BUGSPLAT_PASSWORD"
     QMAKE_POST_LINK += "&& cp $$PWD/Crashpad/attachment.txt $$OUT_PWD/attachment.txt"
 }

--- a/myQtCrasher.pro
+++ b/myQtCrasher.pro
@@ -38,7 +38,7 @@ RESOURCES += \
 # BugSplat configuration options
 BUGSPLAT_DATABASE = fred
 BUGSPLAT_APPLICATION = myQtCrasher
-BUGSPLAT_VERSION = 1.1
+BUGSPLAT_VERSION = 1.2
 BUGSPLAT_USER = fred@bugsplat.com
 BUGSPLAT_PASSWORD = Flintstone
 
@@ -72,7 +72,7 @@ macx {
     # Copy crashpad_handler, attachment.txt to build directory, and upload symbols
     QMAKE_POST_LINK += "mkdir -p $$OUT_PWD/crashpad"
     QMAKE_POST_LINK += "&& cp $$PWD/Crashpad/Bin/MacOS/$$ARCH/crashpad_handler $$OUT_PWD/crashpad"
-    QMAKE_POST_LINK += "&& bash $$PWD/Crashpad/Tools/MacOS/symbols.sh $$PWD $$OUT_PWD $$BUGSPLAT_DATABASE $$BUGSPLAT_APPLICATION $$BUGSPLAT_VERSION $$BUGSPLAT_USER $$BUGSPLAT_PASSWORD"
+    QMAKE_POST_LINK += "&& bash $$PWD/Crashpad/Tools/MacOS/symbols.sh $$PWD $$OUT_PWD $$BUGSPLAT_DATABASE $$BUGSPLAT_APPLICATION $$BUGSPLAT_VERSION $$BUGSPLAT_USER $$BUGSPLAT_PASSWORD $$ARCH"
     QMAKE_POST_LINK += "&& cp $$PWD/Crashpad/attachment.txt $$OUT_PWD/attachment.txt"
 }
 
@@ -100,7 +100,7 @@ win32 {
     # Copy crashpad_handler, attachment.txt to build directory, and upload symbols
     QMAKE_POST_LINK += "mkdir $$shell_path($$OUT_PWD)\crashpad"
     QMAKE_POST_LINK += "& copy /y $$shell_path($$PWD)\Crashpad\Bin\Windows\crashpad_handler.exe $$shell_path($$OUT_PWD)\crashpad\crashpad_handler.exe"
-    QMAKE_POST_LINK += "&& $$shell_path($$PWD)\Crashpad\Tools\Windows\symbols.bat $$shell_path($$PWD) $$shell_path($$EXEDIR) $$BUGSPLAT_DATABASE $$BUGSPLAT_APPLICATION $$BUGSPLAT_VERSION $$BUGSPLAT_USER $$BUGSPLAT_PASSWORD"
+    QMAKE_POST_LINK += "&& powershell -ExecutionPolicy Bypass -NoProfile -Command \"& {& '$$shell_path($$PWD)\Crashpad\Tools\Windows\symbols.ps1' -rootPath '$$shell_path($$PWD)' -symbolsDir '$$shell_path($$EXEDIR)' -database '$$BUGSPLAT_DATABASE' -appName '$$BUGSPLAT_APPLICATION' -version '$$BUGSPLAT_VERSION' -username '$$BUGSPLAT_USER' -password '$$BUGSPLAT_PASSWORD'}\""
     QMAKE_POST_LINK += "&& copy /y $$shell_path($$PWD)\Crashpad\attachment.txt $$shell_path($$OUT_PWD)\attachment.txt"
 }
 

--- a/paths.cpp
+++ b/paths.cpp
@@ -5,7 +5,7 @@ Paths::Paths(QString exeDir) {
 }
 
 QString Paths::getAttachmentPath() {
-    #if defined(Q_OS_MACOS) || defined(Q_OS_MAC64)
+    #if defined(Q_OS_MACOS)
         return m_exeDir + "/../../../attachment.txt";
     #elif defined(Q_OS_WINDOWS)
         return m_exeDir + "\\..\\attachment.txt";


### PR DESCRIPTION
### Description

Avoids LFS nonsense. Ensures symbol-upload is newest version.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
